### PR TITLE
rm catch all rescue from middleware

### DIFF
--- a/lib/optics-agent/rack-middleware.rb
+++ b/lib/optics-agent/rack-middleware.rb
@@ -8,36 +8,31 @@ module OpticsAgent
     end
 
     def call(env)
-      begin
-        start_time = Time.now
+      start_time = Time.now
 
-        # XXX: figure out a way to pass this in here
-        agent = OpticsAgent::Agent.instance
-        query = OpticsAgent::Reporting::Query.new
+      # XXX: figure out a way to pass this in here
+      agent = OpticsAgent::Agent.instance
+      query = OpticsAgent::Reporting::Query.new
 
-        # Attach so resolver middleware can access
-        env[:optics_agent] = {
-          agent: agent,
-          query: query
-        }
-        env[:optics_agent].define_singleton_method(:with_document) do |document|
-          self[:query].document = document
-          self
-        end
-
-        result = @app.call(env)
-
-        # XXX: this approach means if the user forgets to call with_document
-        # we just never log queries. Can we detect if the request is a graphql one?
-        if (query.document)
-          agent.add_query(query, env, start_time, Time.now)
-        end
-
-        result
-      rescue Exception => e
-        puts "Rack Middleware Error: #{e}"
-        puts e.backtrace
+      # Attach so resolver middleware can access
+      env[:optics_agent] = {
+        agent: agent,
+        query: query
+      }
+      env[:optics_agent].define_singleton_method(:with_document) do |document|
+        self[:query].document = document
+        self
       end
+
+      result = @app.call(env)
+
+      # XXX: this approach means if the user forgets to call with_document
+      # we just never log queries. Can we detect if the request is a graphql one?
+      if (query.document)
+        agent.add_query(query, env, start_time, Time.now)
+      end
+
+      result
     end
   end
 end


### PR DESCRIPTION
I don't think we want to rescue all Exceptions here 🐱 

Let's remove that rescue for now, and at least catch errors specific to the middleware if needed later ?

I don't think it has much use seeing it's only logging to STDOUT

@tmeasday