### PR TITLE
with_document should accept the graphql document, not a params hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ Add something like this to your route:
 ```ruby
 post '/graphql' do
   request.body.rewind
-  document = JSON.parse request.body.read
-  result = Schema.execute(document["query"],
-    variables: document["variables"],
+  params = JSON.parse request.body.read
+  document = params['query']
+  variables = params['variables']
+
+  result = Schema.execute(
+    document,
+    variables: variables,
     context: { optics_agent: env[:optics_agent].with_document(document) }
   )
+
   JSON.generate(result)
 end
 ```
@@ -87,12 +92,15 @@ Register Optics Agent on the GraphQL context within your `graphql` action as bel
 def create
   query_string = params[:query]
   query_variables = ensure_hash(params[:variables])
-  result = YourSchema.execute(query_string,
+
+  result = YourSchema.execute(
+    query_string,
     variables: query_variables,
     context: {
-      optics_agent: env[:optics_agent].with_document(params)
+      optics_agent: env[:optics_agent].with_document(query_string)
     }
   )
+
   render json: result
 end
 ```

--- a/lib/optics-agent/reporting/query.rb
+++ b/lib/optics-agent/reporting/query.rb
@@ -28,7 +28,7 @@ module OpticsAgent::Reporting
         throw "You must call .with_document on the optics context"
       end
 
-      @signature ||= normalize(document["query"].to_s)
+      @signature ||= normalize(document.to_s)
     end
 
     # we do nothing when reporting to minimize impact

--- a/spec/query_trace_spec.rb
+++ b/spec/query_trace_spec.rb
@@ -6,24 +6,13 @@ require 'graphql'
 include Apollo::Optics::Proto
 include OpticsAgent::Reporting
 
-class DocumentMock
-  def initialize(key)
-    @key = key
-  end
-
-  def [](name) # used for [:query]
-    @key
-  end
-end
-
-
 describe QueryTrace do
   it "can represent a simple query" do
     query = Query.new
     query.report_field 'Person', 'firstName', 1, 1.1
     query.report_field 'Person', 'lastName', 1, 1.1
     query.report_field 'Query', 'person', 1, 1.22
-    query.document = DocumentMock.new('{field}')
+    query.document = '{field}'
 
     trace = QueryTrace.new(query, {}, 1, 1.25)
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -6,24 +6,13 @@ require 'graphql'
 include OpticsAgent::Reporting
 include Apollo::Optics::Proto
 
-class DocumentMock
-  def initialize(key)
-    @key = key
-  end
-
-  def [](name) # used for [:query]
-    @key
-  end
-end
-
-
 describe Report do
   it "can represent a simple query" do
     query = Query.new
     query.report_field 'Person', 'firstName', 1, 1.1
     query.report_field 'Person', 'lastName', 1, 1.1
     query.report_field 'Query', 'person', 1, 1.22
-    query.document = DocumentMock.new('{field}')
+    query.document = '{field}'
 
     report = Report.new
     report.add_query query, {}, 1, 1.25
@@ -52,13 +41,13 @@ describe Report do
     queryOne.report_field 'Person', 'firstName', 1, 1.1
     queryOne.report_field 'Person', 'lastName', 1, 1.1
     queryOne.report_field 'Query', 'person', 1, 1.22
-    queryOne.document = DocumentMock.new('{field}')
+    queryOne.document = '{field}'
 
     queryTwo = Query.new
     queryTwo.report_field 'Person', 'firstName', 1, 1.05
     queryTwo.report_field 'Person', 'lastName', 1, 1.05
     queryTwo.report_field 'Query', 'person', 1, 1.2
-    queryTwo.document = DocumentMock.new('{field}')
+    queryTwo.document = '{field}'
 
     report = Report.new
     report.add_query queryOne, {}, 1, 1.1
@@ -88,13 +77,13 @@ describe Report do
     queryOne.report_field 'Person', 'firstName', 1, 1.1
     queryOne.report_field 'Person', 'lastName', 1, 1.1
     queryOne.report_field 'Query', 'person', 1, 1.22
-    queryOne.document = DocumentMock.new('{fieldOne}')
+    queryOne.document = '{fieldOne}'
 
     queryTwo = Query.new
     queryTwo.report_field 'Person', 'firstName', 1, 1.05
     queryTwo.report_field 'Person', 'lastName', 1, 1.05
     queryTwo.report_field 'Query', 'person', 1, 1.02
-    queryTwo.document = DocumentMock.new('{fieldTwo}')
+    queryTwo.document = '{fieldTwo}'
 
     report = Report.new
     report.add_query queryOne, {}, 1, 1.1
@@ -123,7 +112,7 @@ describe Report do
     query = Query.new
     query.report_field 'Person', 'firstName', 1, 1.1
     query.report_field 'Person', 'age', 1, 1.1
-    query.document = DocumentMock.new('{field}')
+    query.document = '{field}'
 
     report = Report.new
     report.add_query query, {}, 1, 1.25
@@ -161,7 +150,7 @@ describe Report do
     query.report_field 'Query', '__schema', 1, 1.1
     query.report_field 'Query', '__typename', 1, 1.1
     query.report_field 'Query', '__type', 1, 1.1
-    query.document = DocumentMock.new('{field}')
+    query.document = '{field}'
 
     report = Report.new
     report.add_query query, {}, 1, 1.25


### PR DESCRIPTION
I believe it's more explicit to take the `query_string` only as a param in `with_document`. It feels weird to pass your whole params hash (like in examples).

`Query` also blindly looks for a "query" parameter, but that could be anything in the params.

WDYT @tmeasday ?

I'll update the docs if we end up going with this solution.