### PR TITLE
refactor(RackMiddleware) use an object for :optics_agent

### DIFF
--- a/lib/optics-agent/graphql-middleware.rb
+++ b/lib/optics-agent/graphql-middleware.rb
@@ -9,7 +9,7 @@ module OpticsAgent
       result = next_middleware.call
       end_time = Time.now
 
-      query = query_context[:optics_agent][:query]
+      query = query_context[:optics_agent].query
       query.report_field(parent_type.to_s, field_definition.name, start_time, end_time)
 
       result

--- a/lib/optics-agent/rack-middleware.rb
+++ b/lib/optics-agent/rack-middleware.rb
@@ -15,14 +15,7 @@ module OpticsAgent
       query = OpticsAgent::Reporting::Query.new
 
       # Attach so resolver middleware can access
-      env[:optics_agent] = {
-        agent: agent,
-        query: query
-      }
-      env[:optics_agent].define_singleton_method(:with_document) do |document|
-        self[:query].document = document
-        self
-      end
+      env[:optics_agent] = RackAgent.new(agent, query)
 
       result = @app.call(env)
 
@@ -33,6 +26,19 @@ module OpticsAgent
       end
 
       result
+    end
+  end
+
+  class RackAgent
+    attr_reader :agent, :query
+    def initialize(agent, query)
+      @agent = agent
+      @query = query
+    end
+
+    def with_document(query_string)
+      @query.document = query_string
+      self
     end
   end
 end

--- a/spec/graphql-middleware_spec.rb
+++ b/spec/graphql-middleware_spec.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'optics-agent/graphql-middleware'
 require 'graphql'
 
@@ -32,7 +33,7 @@ describe GraphqlMiddleware do
 
     query = spy("query")
     schema.execute('{ person { firstName lastName } }', {
-      context: { optics_agent: { query: query } }
+      context: { optics_agent: OpenStruct.new(query: query) }
     })
 
     expect(query).to have_received(:report_field).exactly(3).times


### PR DESCRIPTION
Ruby's method cache is a fickle beast. We should avoid invalidating it! I don't _exactly_ know what the cost of `define_singleton_method` is, but I know that it's best to avoid defining methods on the "hot path", see for reference: 

http://mensfeld.pl/2015/04/ruby-global-method-cache-invalidation-impact-on-a-single-and-multithreaded-applications/
